### PR TITLE
fix(): correctly parse video URLs with queryParams

### DIFF
--- a/src/web-utils/videoplayer.ts
+++ b/src/web-utils/videoplayer.ts
@@ -288,7 +288,7 @@ export class VideoPlayer {
   private _getVideoType(): boolean {
     let ret = false;
     let vType = '';
-    const sUrl: string = this._url ? this._url : '';
+    const sUrl: string = this._url ? this._url.split('?')[0] : '';
     if (sUrl != null && sUrl.length > 0) {
       try {
         const val = sUrl.substring(sUrl.lastIndexOf('/')).match(/(.*)\.(.*)/);
@@ -312,18 +312,6 @@ export class VideoPlayer {
             this._videoType = 'application/x-mpegURL';
             break;
           }
-          /*
-                  case "mpd" : {
-                  this._videoType = "application/dash+xml";
-                  break;
-                  }
-          */
-          /*
-                  case "youtube" : {
-                  this._videoType = "video/youtube";
-                  break;
-                  }
-          */
           default: {
             this._videoType = null;
             break;


### PR DESCRIPTION
When the source element for the video URL had query parameters (a `?` in the URL) it incorrectly parsed the extension of the video, leading to the video player not loading anything.

This fix removes the query parameters in the `_getVideoType` method as, in this point, they don't matter.