### PR TITLE
fix(): hjs event update

### DIFF
--- a/src/web-utils/videoplayer.ts
+++ b/src/web-utils/videoplayer.ts
@@ -239,7 +239,7 @@ export class VideoPlayer {
           const hls = new Hls();
           hls.loadSource(this._url);
           hls.attachMedia(this.videoEl);
-          hls.on(Hls.Events.MANIFEST_PARSED, () => {
+          hls.on(Hls.Events.FRAG_PARSED, () => {
             if (this.videoEl != null) {
               this.videoEl.muted = true;
               this.videoEl.crossOrigin = 'anonymous';


### PR DESCRIPTION
Replace `MANIFEST_PARSED` event with `FRAG_PARSED` so video has being loaded into the DOM and duration can be retrieved correctly (currently if you init the player and immediately try to update the video time you'll get a NaN for the video duration as it hasn't been loaded yet, hence no duration can be retrieved.

By using the `FRAG_PARSED` we make sure at least a portion of the video has been loaded so the duration of the video can be retrieved correctly.