### PR TITLE
feat(): refactor getVideoType function

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -2,7 +2,7 @@
 <h3 align="center">Video Player</h3>
 <p align="center"><strong><code>capacitor-video-player</code></strong></p>
 <br>
-<p align="center" style="font-size:50px;color:red"><strong>CAPACITOR 5 </strong></p><br>
+<p align="center" style="font-size:50px;color:red"><strong>CAPACITOR 6</strong></p><br>
 <br>
 <p align="center" style="font-size:20px;color:red"><a href="https://github.com/jepiqueau/capacitor-video-player/blob/master/docs/Jean_Pierre_Queau.md"><strong>Special note from Jean Pierre Quéau the original founder of this project.</strong></a></p>
 <br>
@@ -22,7 +22,7 @@
   <a href="https://www.npmjs.com/package/capacitor-video-player"><img src="https://img.shields.io/npm/dw/capacitor-video-player?style=flat-square" /></a>
   <a href="https://www.npmjs.com/package/capacitor-video-player"><img src="https://img.shields.io/npm/v/capacitor-video-player?style=flat-square" /></a>
 <!-- ALL-CONTRIBUTORS-BADGE:START - Do not remove or modify this section -->
-<a href="#contributors-"><img src="https://img.shields.io/badge/all%20contributors-9-orange?style=flat-square" /></a>
+<a href="#contributors-"><img src="https://img.shields.io/badge/all%20contributors-10-orange?style=flat-square" /></a>
 <!-- ALL-CONTRIBUTORS-BADGE:END -->
 </p>
 
@@ -175,8 +175,11 @@ Thanks goes to these wonderful people ([emoji key](https://allcontributors.org/d
     <td align="center"><a href="https://github.com/PhantomPainX"><img src="https://avatars.githubusercontent.com/u/47803967?v=4" width="100px;" alt=""/><br /><sub><b>Manuel García Marín</b></sub></a><br /><a href="https://github.com/jepiqueau/capacitor-video-player/commits?author=PhantomPainX" title="Code">💻</a></td>
     <td align="center"><a href="https://github.com/j-oppenhuis"><img src="https://avatars.githubusercontent.com/u/46529655?v=4" width="100px;" alt=""/><br /><sub><b>Jelle Oppenhuis</b></sub></a><br /><a href="https://github.com/jepiqueau/capacitor-video-player/commits?author=j-oppenhuis" title="Code">💻</a></td>
     <td align="center"><a href="https://github.com/fegauthier"><img src="https://avatars.githubusercontent.com/u/12112673?v=4" width="100px;" alt=""/><br /><sub><b>fegauthier</b></sub></a><br /><a href="https://github.com/jepiqueau/capacitor-video-player/commits?author=fegauthier" title="Code">💻</a></td>
-    <td align="center"><a href="https://github.com/harmonwood"><img src="https://avatars.githubusercontent.com/u/460843?v=4" width="100px;" alt="Harmon Wood"/><br /><sub><b>Harmon WooD</b></sub></a><br /><a href="https://github.com/harmonwood/capacitor-video-player/commits?author=harmonwood" title="Code">💻</a></td>
     
+  </tr>
+  <tr>
+    <td align="center"><a href="https://github.com/harmonwood"><img src="https://avatars.githubusercontent.com/u/460843?v=4" width="100px;" alt="Harmon Wood"/><br /><sub><b>Harmon Wood</b></sub></a><br /><a href="https://github.com/harmonwood/capacitor-video-player/commits?author=harmonwood" title="Code">💻</a></td>
+    <td align="center"><a href="https://github.com/eduardoRoth"><img src="https://avatars.githubusercontent.com/u/5419161?v=4" width="100px;" alt="Eduardo Roth"/><br /><sub><b>Eduardo Roth</b></sub></a><br /><a href="https://github.com/harmonwood/capacitor-video-player/commits?author=eduardoroth" title="Code">💻</a></td>
   </tr>
 </table>
 

--- a/src/web-utils/video-types.ts
+++ b/src/web-utils/video-types.ts
@@ -1,0 +1,10 @@
+export type extension = 'mp4' | 'webm' | 'cmaf' | 'cmfv' | 'm3u8';
+export type mimeType = 'video/mp4' | 'application/x-mpegURL';
+
+export const videoTypes: Record<extension, mimeType> = {
+  mp4: 'video/mp4',
+  webm: 'video/mp4',
+  cmaf: 'video/mp4',
+  cmfv: 'video/mp4',
+  m3u8: 'application/x-mpegURL',
+};

--- a/src/web-utils/video-types.ts
+++ b/src/web-utils/video-types.ts
@@ -1,6 +1,6 @@
-export type extension = 'mp4' | 'webm' | 'cmaf' | 'cmfv' | 'm3u8';
-export type mimeType = 'video/mp4' | 'application/x-mpegURL';
-export const possibleQueryParameterExtensions: Array<string> = [
+export type videoExtension = 'mp4' | 'webm' | 'cmaf' | 'cmfv' | 'm3u8';
+export type videoMimeType = 'video/mp4' | 'application/x-mpegURL';
+export const possibleQueryParameterExtensions: string[] = [
   'file',
   'extension',
   'filetype',
@@ -8,7 +8,7 @@ export const possibleQueryParameterExtensions: Array<string> = [
   'ext',
 ];
 
-export const videoTypes: Record<extension, mimeType> = {
+export const videoTypes: Record<videoExtension, videoMimeType> = {
   mp4: 'video/mp4',
   webm: 'video/mp4',
   cmaf: 'video/mp4',

--- a/src/web-utils/video-types.ts
+++ b/src/web-utils/video-types.ts
@@ -1,6 +1,6 @@
 export type extension = 'mp4' | 'webm' | 'cmaf' | 'cmfv' | 'm3u8';
 export type mimeType = 'video/mp4' | 'application/x-mpegURL';
-export const possibleQueryParameterExtensionVars: Array<string> = [
+export const possibleQueryParameterExtensions: Array<string> = [
   'file',
   'extension',
   'filetype',

--- a/src/web-utils/video-types.ts
+++ b/src/web-utils/video-types.ts
@@ -1,5 +1,12 @@
 export type extension = 'mp4' | 'webm' | 'cmaf' | 'cmfv' | 'm3u8';
 export type mimeType = 'video/mp4' | 'application/x-mpegURL';
+export const possibleQueryParameterExtensionVars: Array<string> = [
+  'file',
+  'extension',
+  'filetype',
+  'type',
+  'ext',
+];
 
 export const videoTypes: Record<extension, mimeType> = {
   mp4: 'video/mp4',

--- a/src/web-utils/videoplayer.ts
+++ b/src/web-utils/videoplayer.ts
@@ -1,5 +1,6 @@
 import Hls from 'hls.js';
-import type { mimeType } from './video-types';
+
+import type { videoMimeType } from './video-types';
 import { videoTypes, possibleQueryParameterExtensions } from './video-types';
 
 export class VideoPlayer {
@@ -16,7 +17,7 @@ export class VideoPlayer {
   private _height: number;
   private _zIndex: number;
   private _initial: any;
-  private _videoType: mimeType | null = null;
+  private _videoType: videoMimeType | null = null;
   private _videoContainer: any = null;
   private _firstReadyToPlay = true;
   private _isEnded = false;
@@ -51,7 +52,7 @@ export class VideoPlayer {
 
   public async initialize(): Promise<void> {
     // get the video type
-    const urlVideoType: mimeType | null = this._getVideoType();
+    const urlVideoType: videoMimeType | null = this._getVideoType();
     if (urlVideoType) {
       // style the container
       if (this._mode === 'fullscreen') {
@@ -288,7 +289,7 @@ export class VideoPlayer {
     });
   }
 
-  private _getVideoType(): mimeType | null {
+  private _getVideoType(): videoMimeType | null {
     const sUrl: string = this._url ? this._url : '';
     if (sUrl != null && sUrl.length > 0) {
       Object.entries(videoTypes).forEach(([extension, mimeType]) => {

--- a/src/web-utils/videoplayer.ts
+++ b/src/web-utils/videoplayer.ts
@@ -287,49 +287,23 @@ export class VideoPlayer {
 
   private _getVideoType(): boolean {
     let ret = false;
-    let vType = '';
     const sUrl: string = this._url ? this._url : '';
     if (sUrl != null && sUrl.length > 0) {
       try {
-        const val = sUrl.substring(sUrl.lastIndexOf('/')).match(/(.*)\.(.*)/);
-        if (val == null) {
-          vType = '';
+        const isHls = sUrl.match(/\.(m3u8)/i);
+        if (isHls) {
+          this._videoType = 'application/x-mpegURL';
+          ret = true;
         } else {
-          const a = sUrl.match(/(.*)\.(.*)/);
-          vType = a != null ? a[2].split('?')[0] : '';
-        }
-        switch (vType) {
-          case 'mp4':
-          case '':
-          case 'webm':
-          case 'cmaf':
-          case 'cmfv':
-          case 'cmfa': {
+          const isMp4 = sUrl.match(/\.(mp4|webm|cmaf|cmfv|cmfa)/i);
+          if (isMp4) {
             this._videoType = 'video/mp4';
-            break;
-          }
-          case 'm3u8': {
-            this._videoType = 'application/x-mpegURL';
-            break;
-          }
-          /*
-                  case "mpd" : {
-                  this._videoType = "application/dash+xml";
-                  break;
-                  }
-          */
-          /*
-                  case "youtube" : {
-                  this._videoType = "video/youtube";
-                  break;
-                  }
-          */
-          default: {
+            ret = true;
+          } else {
             this._videoType = null;
-            break;
+            ret = false;
           }
         }
-        ret = true;
       } catch {
         ret = false;
       }

--- a/src/web-utils/videoplayer.ts
+++ b/src/web-utils/videoplayer.ts
@@ -1,6 +1,6 @@
 import Hls from 'hls.js';
 import type { mimeType } from './video-types';
-import { videoTypes, possibleQueryParameterExtensionVars } from './video-types';
+import { videoTypes, possibleQueryParameterExtensions } from './video-types';
 
 export class VideoPlayer {
   public videoEl: HTMLVideoElement | undefined;
@@ -315,7 +315,7 @@ export class VideoPlayer {
       // e.g. https://youtube.com/?v=3982748927&filetype=mkv
       const hasNotSupportedExtensionInUrl = sUrl.match(
         new RegExp(
-          `(${possibleQueryParameterExtensionVars.join('|')})\=+(.*)&?(?=&|$))`,
+          `(${possibleQueryParameterExtensions.join('|')})\=+(.*)&?(?=&|$))`,
           'i',
         ),
       );


### PR DESCRIPTION
Refactors the getVideoType method to correctly check the file extension. Supports the same extension types as before, but now it doesn't expect the regexp match to be at the end of the URL.